### PR TITLE
Clear flash messages without requiring sending a message to the LV

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,7 +1,7 @@
 // We need to import the CSS so that webpack will load it.
 // The MiniCssExtractPlugin is used to separate it out into
 // its own CSS file.
-import "../css/app.scss"
+import "../css/app.scss";
 
 // webpack automatically bundles all modules in your
 // entry points. Those entry points can be configured
@@ -12,22 +12,49 @@ import "../css/app.scss"
 //     import {Socket} from "phoenix"
 //     import socket from "./socket"
 //
-import "phoenix_html"
-import {Socket} from "phoenix"
-import NProgress from "nprogress"
-import {LiveSocket} from "phoenix_live_view"
+import "phoenix_html";
+import { Socket } from "phoenix";
+import NProgress from "nprogress";
+import { LiveSocket } from "phoenix_live_view";
 
-let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let Hooks = {};
+Hooks.FlashCountdown = {
+  mounted() {
+    this.startTimeout(this.el);
+  },
+  destroyed() {
+    this.clearTimeout(this.el);
+  },
+  startTimeout(el) {
+    var t;
+    t = setTimeout(() => {
+      console.log("clicking");
+      el.click();
+    }, 3000);
+
+    el.flashCountdown = t;
+  },
+  clearTimeout(el) {
+    clearTimeout(el.flashCountdown);
+  },
+};
+
+let csrfToken = document
+  .querySelector("meta[name='csrf-token']")
+  .getAttribute("content");
+let liveSocket = new LiveSocket("/live", Socket, {
+  params: { _csrf_token: csrfToken },
+  hooks: Hooks,
+});
 
 // Show progress bar on live navigation and form submits
-window.addEventListener("phx:page-loading-start", info => NProgress.start())
-window.addEventListener("phx:page-loading-stop", info => NProgress.done())
+window.addEventListener("phx:page-loading-start", (info) => NProgress.start());
+window.addEventListener("phx:page-loading-stop", (info) => NProgress.done());
 
 // connect if there are any LiveViews on the page
-liveSocket.connect()
+liveSocket.connect();
 
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)
-window.liveSocket = liveSocket
+window.liveSocket = liveSocket;

--- a/lib/organizer_web/live/todo_live/index.ex
+++ b/lib/organizer_web/live/todo_live/index.ex
@@ -20,8 +20,6 @@ defmodule OrganizerWeb.TodoLive.Index do
       |> assign(:user, get_user(list_id))
       |> assign(:list_id, list_id)
 
-    # clearing whichever flash message, after 3 seconds
-    if connected?(socket), do: Process.send_after(self(), :clear_flash, 3000)
     {:ok, socket}
   end
 
@@ -84,7 +82,8 @@ defmodule OrganizerWeb.TodoLive.Index do
     socket
     |> assign(:page_title, "Listing Todos")
     |> assign(:todo, nil)
-    |> assign(:todos, list_todos(socket.assigns.list_id)) # need this here rather than in mount, because of push_patch
+    # need this here rather than in mount, because of push_patch
+    |> assign(:todos, list_todos(socket.assigns.list_id))
   end
 
   @impl true

--- a/lib/organizer_web/templates/layout/live.html.leex
+++ b/lib/organizer_web/templates/layout/live.html.leex
@@ -1,11 +1,17 @@
 <main role="main" class="container">
-  <p class="alert alert-info animated fade-out" role="alert"
-    phx-click="lv:clear-flash"
-    phx-value-key="info"><%= live_flash(@flash, :info) %></p>
+  <%= if message = live_flash(@flash, :info) do %>
+    <p class="alert alert-info animated fade-out" role="alert"
+      phx-hook="FlashCountdown"
+      phx-click="lv:clear-flash"
+      phx-value-key="info"><%= message %></p>
+  <% end %>
 
-  <p class="alert alert-danger animated fade-out" role="alert"
-    phx-click="lv:clear-flash"
-    phx-value-key="error"><%= live_flash(@flash, :error) %></p>
+  <%= if message = live_flash(@flash, :error) do %>
+    <p class="alert alert-danger animated fade-out" role="alert"
+      phx-hook="FlashCountdown"
+      phx-click="lv:clear-flash"
+      phx-value-key="error"><%= message %></p>
+  <% end %>
 
   <%= @inner_content %>
 </main>


### PR DESCRIPTION
Hey!

Just a small follow up.

I saw in another thread on the elixirforum.com that you asked how to do this.

I think this is more convenient than sending a message to clear flash on every LV. This leverages the Phoenix hooks to mimic the user clicking the flash message after 3 seconds.

I left a `console.log` debug so you can see it only happens once and only when the message is displayed.